### PR TITLE
fix(deps): force a release

### DIFF
--- a/.buildkite/docker/Dockerfile
+++ b/.buildkite/docker/Dockerfile
@@ -5,7 +5,6 @@ RUN apk update && apk add --no-cache git
 
 COPY package.json package-lock.json ./
 
-# --legacy-peer-deps required as we are upgrading from npm 6 to npm 8
-RUN npm ci --legacy-peer-deps
+RUN npm ci
 
 RUN git config --global --add safe.directory /app


### PR DESCRIPTION
jigger things so semantic-release actually releases a new version

## Checklist

- [ ] Deployed to an environment
- [x] PR has appropriate labels added (needs-testing, etc.)
- [x] Authentication is on point (you are who you say you are)
- [x] Authorisation is on point (you are allowed to access this)
- [x] Data and input/output validation controls (SQL injection, XSS attacks, file validation, type conversion)
- [x] Error and exception handling controls (transaction rollbacks, parsing external errors)
- [x] Any newly introduced PII or confidential data is appropriately handled.  This includes external systems like Rollbar and Datadog, but also applies internally to Dupliplacer, Umbrella_Placer and the like.
- [x] Any schema changes have been notified to the data platform team in #data-change-notifications on slack.
- [x] Aware of the downstream/upstream effects this change will have. The Marketplacer ecosystem is beyond complicated and now has many system dependencies.  Take the time to understand how your change interacts with them and speak to some teams if you need to (MConnect, Cerberus, Graphql, API V2, Headless, Connected, Fullstack, Minsights, Umbrella_Placer, Spreadsheet Uploaders, MStores, MultiStores, and more!)
- [x] Supporting documentation published. A release is not just pushing a code change, it's also communicating it.
In-App documentation, Knowledgebase, API Docs, Tettra Docs, Postman Collection, Lucid Charts, and your PM knows what's up.
