### PR TITLE
chore: update node version to 22

### DIFF
--- a/.buildkite/docker/Dockerfile
+++ b/.buildkite/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:22-alpine
 WORKDIR /app
 
 RUN apk update && apk add --no-cache git


### PR DESCRIPTION
Bump node version to 22 as it's now LTS

resolves https://marketplacer.atlassian.net/browse/PE1-1142

## Checklist

- [ ] Deployed to an environment
- [ ] PR has appropriate labels added (needs-testing, etc.)
- [ ] Authentication is on point (you are who you say you are)
- [ ] Authorisation is on point (you are allowed to access this)
- [ ] Data and input/output validation controls (SQL injection, XSS attacks, file validation, type conversion)
- [ ] Error and exception handling controls (transaction rollbacks, parsing external errors)
- [ ] Any newly introduced PII or confidential data is appropriately handled.  This includes external systems like Rollbar and Datadog, but also applies internally to Dupliplacer, Umbrella_Placer and the like.
- [ ] Any schema changes have been notified to the data platform team in #data-change-notifications on slack.
- [ ] Aware of the downstream/upstream effects this change will have. The Marketplacer ecosystem is beyond complicated and now has many system dependencies.  Take the time to understand how your change interacts with them and speak to some teams if you need to (MConnect, Cerberus, Graphql, API V2, Headless, Connected, Fullstack, Minsights, Umbrella_Placer, Spreadsheet Uploaders, MStores, MultiStores, and more!)
- [ ] Supporting documentation published. A release is not just pushing a code change, it's also communicating it.
In-App documentation, Knowledgebase, API Docs, Confluence Docs, Postman Collection, Lucid Charts, and your PM knows what's up.

**See:** https://marketplacer.atlassian.net/wiki/spaces/PT/pages/46170530/System+Acquisition+and+Development+Policy
**See:** https://marketplacer.atlassian.net/wiki/spaces/PT/pages/14156267/threat-modelling
